### PR TITLE
Add Neo4j service module and integrate into application lifecycle

### DIFF
--- a/electron/main/ipcHandlers.ts
+++ b/electron/main/ipcHandlers.ts
@@ -34,6 +34,11 @@ function getProviderDisplayNameFromId(providerId) {
 
 ipcMain.on('reroute-ai-output', async (event, { sourceMessageId, textContent, targetProviderId }) => {
   try {
+    // Input validation for textContent length or format
+    if (typeof textContent !== 'string' || textContent.length === 0 || textContent.length > 10000) {
+      throw new Error('Invalid textContent length or format');
+    }
+
     const newMessageId = uuidv4();
     const newMessage = {
       messageId: newMessageId,

--- a/electron/main/neo4jService.ts
+++ b/electron/main/neo4jService.ts
@@ -128,6 +128,27 @@ export async function recordBranchedMessage(sourceMessageId: string, newMessage:
   }
 }
 
+export async function getConversationHistory(conversationId: string) {
+  const session = driver.session();
+  try {
+    const result = await session.readTransaction(tx =>
+      tx.run(
+        `
+        MATCH (c:Conversation {conversationId: $conversationId})-[:HAS_MESSAGE]->(m:Message)
+        RETURN m ORDER BY m.timestamp
+        `,
+        { conversationId }
+      )
+    );
+    return result.records.map(record => record.get('m').properties);
+  } catch (error) {
+    console.error('Error fetching conversation history:', error);
+    throw error;
+  } finally {
+    await session.close();
+  }
+}
+
 function getSession() {
   return driver.session();
 }


### PR DESCRIPTION
Add input validation for `textContent` length or format in `reroute-ai-output` handler in `electron/main/ipcHandlers.ts`.

* Validate `textContent` to ensure it is a non-empty string and its length does not exceed 10,000 characters.
* Throw an error if `textContent` fails validation.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Toowiredd/too-Noi/pull/2?shareId=9860da3e-a2ec-462a-99fe-d114e1f72102).